### PR TITLE
Change exception type

### DIFF
--- a/Test.Utility.Test/TypesThatNeedToBeImplementedInAssemblyRetrieverTest.cs
+++ b/Test.Utility.Test/TypesThatNeedToBeImplementedInAssemblyRetrieverTest.cs
@@ -53,7 +53,7 @@ namespace Messerli.Test.Utility.Test
         }
 
         [Theory]
-        [TypesThatNeedToBeImplementedInAssemblyData("Foo")]
+        [TypesThatNeedToBeImplementedInAssemblyData(TestAssemblyName)]
         [ExcludedTypes(typeof(IInterfaceWithMethod), typeof(ImplementationFactory))]
         [ExcludedTypes(typeof(AbstractClassWithProperty))]
         public void AttributeSmokeTest(Type type)

--- a/Test.Utility.Test/TypesThatNeedToBeImplementedInAssemblyRetrieverTest.cs
+++ b/Test.Utility.Test/TypesThatNeedToBeImplementedInAssemblyRetrieverTest.cs
@@ -48,12 +48,12 @@ namespace Messerli.Test.Utility.Test
         [Fact]
         public void ThrowsWhenAssemblyIsNotFound()
         {
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<InvalidOperationException>(() =>
                 TypesThatNeedToBeImplementedInAssemblyRetriever.GetTypesThatNeedToBeImplementedInAssembly("NonExistingAssembly"));
         }
 
         [Theory]
-        [TypesThatNeedToBeImplementedInAssemblyData(TestAssemblyName)]
+        [TypesThatNeedToBeImplementedInAssemblyData("Foo")]
         [ExcludedTypes(typeof(IInterfaceWithMethod), typeof(ImplementationFactory))]
         [ExcludedTypes(typeof(AbstractClassWithProperty))]
         public void AttributeSmokeTest(Type type)

--- a/Test.Utility/TypesThatNeedToBeImplementedInAssemblyRetriever.cs
+++ b/Test.Utility/TypesThatNeedToBeImplementedInAssemblyRetriever.cs
@@ -7,6 +7,9 @@ namespace Messerli.Test.Utility
 {
     internal static class TypesThatNeedToBeImplementedInAssemblyRetriever
     {
+        /// <exception cref="InvalidOperationException">Thrown when the assembly is not loaded or invalid.</exception>
+        // Note to future developer: When throwing new exception types make sure that they are displayed by the test explorer.
+        // Exceptions that don't get displayed properly are: ArgumentException
         public static IEnumerable<Type> GetTypesThatNeedToBeImplementedInAssembly(string assemblyName)
             => GetAssemblyFromLoadedAssemblies(assemblyName)
                 .GetTypes()
@@ -17,7 +20,7 @@ namespace Messerli.Test.Utility
             => AppDomain.CurrentDomain
                 .GetAssemblies()
                 .SingleOrDefault(assembly => assembly.GetName().Name == assemblyName)
-                    ?? throw new ArgumentException($"Assembly '{assemblyName}' is not loaded or does not exist", nameof(assemblyName));
+                    ?? throw new InvalidOperationException($"Assembly '{assemblyName}' is not loaded or does not exist");
 
         private static bool IsImplementableType(Type type)
             => IsDelegate(type) || IsImplementableInterface(type) || IsAbstractClass(type);

--- a/changelog.md
+++ b/changelog.md
@@ -61,3 +61,7 @@ Rerelease of 0.6.0 with fixed nuget package.
 
 ## 0.7.3
 - Allow blacklisting of types on `TypesThatNeedToBeImplementedInAssemblyData` attribute using a new attribute: `ExcludedTypes`.
+
+## Unreleased
+- Make sure that the exception thrown by the `TypesThatNeedToBeImplementedInAssemblyData` attribute
+  when the specified assembly can't be found is displayed in the test explorer.


### PR DESCRIPTION
Make sure that the exception thrown by the `TypesThatNeedToBeImplementedInAssemblyData` attribute when the specified assembly can't be found is displayed in the test explorer.